### PR TITLE
Generate StackQL provider directly from Smithy models

### DIFF
--- a/smithy-to-openapi/process_models.py
+++ b/smithy-to-openapi/process_models.py
@@ -6,6 +6,11 @@ from pathlib import Path
 from processors import (
     rest_json1, rest_xml, aws_json_1_0, aws_json_1_1, aws_query, ec2_query
 )
+from processors.shared_functions import (
+    reset_processed_services,
+    generate_provider_yaml,
+    PROVIDER_VERSION
+)
 
 PROTOCOL_DISPATCH = {
     "aws.protocols#restJson1": rest_json1.process,
@@ -86,25 +91,22 @@ if __name__ == "__main__":
 
     # Clean output directory if requested
     if args.clean:
-        output_dir = Path("smithy-to-openapi/openapi")
+        output_dir = Path(f"smithy-to-openapi/openapi/src/aws/{PROVIDER_VERSION}")
         if output_dir.exists():
             print(f"🧹 Cleaning output directory: {output_dir}")
-            # Preserve .gitignore if it exists
-            gitignore_path = output_dir / ".gitignore"
-            gitignore_content = None
-            if gitignore_path.exists():
-                gitignore_content = gitignore_path.read_text()
-            
             shutil.rmtree(output_dir)
-            output_dir.mkdir(parents=True, exist_ok=True)
-            
-            # Restore .gitignore if it existed
-            if gitignore_content:
-                gitignore_path.write_text(gitignore_content)
+        output_dir.mkdir(parents=True, exist_ok=True)
 
+    # Reset the processed services list
+    reset_processed_services()
+
+    # Process all services
     for svc in extract_services(Path("models")):
         protocol = svc["protocol"]
         if protocol in PROTOCOL_DISPATCH:
             PROTOCOL_DISPATCH[protocol](svc)
         else:
             print(f"❓ Skipping {svc['servicename']} — unknown protocol: {protocol}")
+
+    # Generate the provider.yaml index file
+    generate_provider_yaml()

--- a/smithy-to-openapi/processors/aws_json_1_0.py
+++ b/smithy-to-openapi/processors/aws_json_1_0.py
@@ -28,10 +28,9 @@ from processors.shared_functions import (
     write_output_yaml,
     derive_resource_name,
     determine_stackql_verb,
+    derive_method_name,
     detect_pagination_scheme,
     add_pagination_to_info,
-    add_pagination_to_operation,
-    resolve_orphaned_schemas,
 )
 
 yaml.add_representer(LiteralStr, literal_str_representer)
@@ -166,31 +165,22 @@ def process(model_entry):
     for operation in shapes_dict["operation"]:
         operation_name = operation["my_name"].split('#')[1]
         key_string = "/#X-Amz-Target=" + service_name2 + "." + operation_name
-        path_spec = create_path(operation, service_name2)
+        path_spec = create_path(operation, service_name2, openapi_spec)
         openapi_spec["paths"][key_string] = path_spec
-        # Add pagination override if this operation is an exception
-        add_pagination_to_operation(openapi_spec, operation["my_name"], path_spec["post"])
-
-    # Resolve any orphaned schema references
-    resolve_orphaned_schemas(openapi_spec)
 
     # Write output YAML
     write_output_yaml(openapi_spec, service_dir)
 
-def create_path(operation, service_name2):
+def create_path(operation, service_name2, openapi_spec):
     result = {}
     operation_name = operation["my_name"].split('#')[1]
+    path_key = "/#X-Amz-Target=" + service_name2 + "." + operation_name
 
     result["post"] = {}
     result_post = result["post"]
 
     result_post["operationId"] = operation_name
-    result_post["x-aws-operation-name"] = operation_name
     result_post["description"] = LiteralStr(html_to_md(operation["traits"].get("smithy.api#documentation", "")))
-    
-    # Add StackQL-specific fields
-    result_post["x-stackql-resource"] = derive_resource_name(operation_name)
-    result_post["x-stackql-verb"] = determine_stackql_verb("POST", operation_name)
 
     # Request body with JSON content
     result_post["requestBody"] = {}
@@ -264,5 +254,21 @@ def create_path(operation, service_name2):
                 }
             }
             error_code += 1
+
+    # Track operation for StackQL resource building
+    resource_name = derive_resource_name(operation_name)
+    stackql_verb = determine_stackql_verb("POST", operation_name)
+    method_name = derive_method_name(operation_name)
+
+    openapi_spec["_stackql_operations"].append({
+        "operation_id": operation_name,
+        "resource_name": resource_name,
+        "stackql_verb": stackql_verb,
+        "method_name": method_name,
+        "path": path_key,
+        "http_method": "post",
+        "success_code": "200",
+        "shape_name": operation["my_name"]
+    })
 
     return result

--- a/smithy-to-openapi/processors/aws_json_1_1.py
+++ b/smithy-to-openapi/processors/aws_json_1_1.py
@@ -1,4 +1,6 @@
-# processors/rest_json1.py
+# processors/aws_json_1_1.py
+# AWS JSON 1.1 protocol processor
+# Uses X-Amz-Target header with POST requests
 
 import json, yaml
 from pathlib import Path
@@ -24,12 +26,12 @@ from processors.shared_functions import (
     add_component_schema_list,
     add_component_schema_union,
     add_component_schema_structure,
-    add_operation,
     detect_pagination_scheme,
     add_pagination_to_info,
-    add_pagination_to_operation,
-    resolve_orphaned_schemas,
     write_output_yaml,
+    derive_resource_name,
+    determine_stackql_verb,
+    derive_method_name,
 )
 
 yaml.add_representer(LiteralStr, literal_str_representer)
@@ -56,6 +58,52 @@ def process(model_entry):
     # Basic OpenAPI structure
     openapi_spec = init_openapi_spec(service_name, service_dir, protocol, version, filename)
 
+    # Add common AWS signature parameters
+    openapi_spec["components"]["parameters"] = {
+        "X-Amz-Content-Sha256": {
+            "name": "X-Amz-Content-Sha256",
+            "in": "header",
+            "required": False,
+            "schema": {"type": "string"}
+        },
+        "X-Amz-Date": {
+            "name": "X-Amz-Date",
+            "in": "header",
+            "required": False,
+            "schema": {"type": "string"}
+        },
+        "X-Amz-Algorithm": {
+            "name": "X-Amz-Algorithm",
+            "in": "header",
+            "required": False,
+            "schema": {"type": "string"}
+        },
+        "X-Amz-Credential": {
+            "name": "X-Amz-Credential",
+            "in": "header",
+            "required": False,
+            "schema": {"type": "string"}
+        },
+        "X-Amz-Security-Token": {
+            "name": "X-Amz-Security-Token",
+            "in": "header",
+            "required": False,
+            "schema": {"type": "string"}
+        },
+        "X-Amz-Signature": {
+            "name": "X-Amz-Signature",
+            "in": "header",
+            "required": False,
+            "schema": {"type": "string"}
+        },
+        "X-Amz-SignedHeaders": {
+            "name": "X-Amz-SignedHeaders",
+            "in": "header",
+            "required": False,
+            "schema": {"type": "string"}
+        }
+    }
+
     shapes = model_data.get("shapes", model_data)
 
     shapes_dict = {
@@ -64,7 +112,7 @@ def process(model_entry):
     }
 
     for shape_name, shape in shapes.items():
-        if shape.get("type") == "service": 
+        if shape.get("type") == "service":
             add_info(openapi_spec, shape, version)
             add_servers(openapi_spec, service_dir, shape)
             shape["my_name"] = shape_name
@@ -98,13 +146,12 @@ def process(model_entry):
         elif shape.get("type") == "structure":
             add_component_schema_structure(openapi_spec, shape_name, shape)
         elif shape.get("type") == "operation":
-            add_operation(openapi_spec, shape_name, shape, shapes)
             shape["my_name"] = shape_name
             shapes_dict["operation"].append(shape)
 
     # process the service to get the paths
     service_name2 = model_entry['servicename'].split('#')[1]
-    
+
     # Sort the operations, we will need them to be in alphabetic order for creating paths
     shapes_dict["operation"].sort(key=lambda x: x["my_name"])
 
@@ -117,52 +164,52 @@ def process(model_entry):
 
     # create the path
     for operation in shapes_dict["operation"]:
-        key_string = "/#X-Amz-Target=" + service_name2 + "." + operation["my_name"].split('#')[1]
-        path_spec = create_path(operation, service_name2)
+        operation_id = operation["my_name"].split('#')[1]
+        key_string = "/#X-Amz-Target=" + service_name2 + "." + operation_id
+        path_spec = create_path(operation, service_name2, openapi_spec)
         openapi_spec["paths"][key_string] = path_spec
-        # Add pagination override if this operation is an exception
-        add_pagination_to_operation(openapi_spec, operation["my_name"], path_spec["post"])
-
-    # Resolve any orphaned schema references
-    resolve_orphaned_schemas(openapi_spec)
 
     # Write output YAML
     write_output_yaml(openapi_spec, service_dir)
 
-def create_path(operation, service_name2):
+def create_path(operation, service_name2, openapi_spec):
     result = {}
+    operation_id = operation["my_name"].split('#')[1]
+    path_key = "/#X-Amz-Target=" + service_name2 + "." + operation_id
+
     result["post"] = {}
     result_post = result["post"]
-    
-    result_post["operationId"] = operation["my_name"].split('#')[1]
+
+    result_post["operationId"] = operation_id
     result_post["description"] = LiteralStr(html_to_md(operation["traits"].get("smithy.api#documentation", "")))
-    
+
     result_post["requestBody"] = {}
     result_request_body = result_post["requestBody"]
     result_request_body["required"] = True
     result_request_body["content"] = {}
     result_request_body["content"]["application/json"] = {}
-    result_request_body["content"]["application/json"]["schema"] = {}    
+    result_request_body["content"]["application/json"]["schema"] = {}
     result_request_body["content"]["application/json"]["schema"]["$ref"] = "#/components/schemas/" + operation["input"]["target"].split("#")[1]
 
-    result_post["parameters"] = {}
-    result_parameters_inside = result_post["parameters"]
-    result_parameters_inside["name"] = "X-Amz-Target"
-    result_parameters_inside["in"] = "header"
-    result_parameters_inside["required"] = True
-    result_parameters_inside["schema"] = {}
-    result_parameters_inside["schema"]["type"] = "string"
-    result_parameters_inside["schema"]["enum"] = [service_name2 + "." + operation["my_name"].split('#')[1]]
+    result_post["parameters"] = [{
+        "name": "X-Amz-Target",
+        "in": "header",
+        "required": True,
+        "schema": {
+            "type": "string",
+            "enum": [service_name2 + "." + operation_id]
+        }
+    }]
 
     # Static Information
     result["parameters"] = []
-    result["parameters"].append({ '$ref': '#/components/parameters/X-Amz-Content-Sha256'})
-    result["parameters"].append({ '$ref': '#/components/parameters/X-Amz-Date'})
-    result["parameters"].append({ '$ref': '#/components/parameters/X-Amz-Algorithm'})
-    result["parameters"].append({ '$ref': '#/components/parameters/X-Amz-Credential'})
-    result["parameters"].append({ '$ref': '#/components/parameters/X-Amz-Security-Token'})
-    result["parameters"].append({ '$ref': '#/components/parameters/X-Amz-Signature'})
-    result["parameters"].append({ '$ref': '#/components/parameters/X-Amz-SignedHeaders'})
+    result["parameters"].append({'$ref': '#/components/parameters/X-Amz-Content-Sha256'})
+    result["parameters"].append({'$ref': '#/components/parameters/X-Amz-Date'})
+    result["parameters"].append({'$ref': '#/components/parameters/X-Amz-Algorithm'})
+    result["parameters"].append({'$ref': '#/components/parameters/X-Amz-Credential'})
+    result["parameters"].append({'$ref': '#/components/parameters/X-Amz-Security-Token'})
+    result["parameters"].append({'$ref': '#/components/parameters/X-Amz-Signature'})
+    result["parameters"].append({'$ref': '#/components/parameters/X-Amz-SignedHeaders'})
 
     result_post["responses"] = {}
     result_responses = result_post["responses"]
@@ -187,5 +234,21 @@ def create_path(operation, service_name2):
             result_responses[error_string]["content"]["application/json"]["schema"] = {"$ref": ('#/components/schemas/' + error_name)}
 
             error_code += 1
+
+    # Track operation for StackQL resource building
+    resource_name = derive_resource_name(operation_id)
+    stackql_verb = determine_stackql_verb("POST", operation_id)
+    method_name = derive_method_name(operation_id)
+
+    openapi_spec["_stackql_operations"].append({
+        "operation_id": operation_id,
+        "resource_name": resource_name,
+        "stackql_verb": stackql_verb,
+        "method_name": method_name,
+        "path": path_key,
+        "http_method": "post",
+        "success_code": "200",
+        "shape_name": operation["my_name"]
+    })
 
     return result

--- a/smithy-to-openapi/processors/aws_query.py
+++ b/smithy-to-openapi/processors/aws_query.py
@@ -29,10 +29,9 @@ from processors.shared_functions import (
     write_output_yaml,
     derive_resource_name,
     determine_stackql_verb,
+    derive_method_name,
     detect_pagination_scheme,
     add_pagination_to_info,
-    add_pagination_to_operation,
-    resolve_orphaned_schemas,
 )
 
 yaml.add_representer(LiteralStr, literal_str_representer)
@@ -167,20 +166,16 @@ def process(model_entry):
     for operation in shapes_dict["operation"]:
         operation_name = operation["my_name"].split('#')[1]
         key_string = f"/#Action={operation_name}"
-        path_spec = create_path(operation, api_version, shapes)
+        path_spec = create_path(operation, api_version, shapes, openapi_spec)
         openapi_spec["paths"][key_string] = path_spec
-        # Add pagination override if this operation is an exception
-        add_pagination_to_operation(openapi_spec, operation["my_name"], path_spec["get"])
-
-    # Resolve any orphaned schema references
-    resolve_orphaned_schemas(openapi_spec)
 
     # Write output YAML
     write_output_yaml(openapi_spec, service_dir)
 
-def create_path(operation, api_version, shapes):
+def create_path(operation, api_version, shapes, openapi_spec):
     result = {}
     operation_name = operation["my_name"].split('#')[1]
+    path_key = f"/#Action={operation_name}"
 
     # AWS signature parameters at path level
     result["parameters"] = [
@@ -194,7 +189,7 @@ def create_path(operation, api_version, shapes):
     ]
 
     # GET method - parameters in query string
-    result["get"] = create_get_operation(operation, operation_name, api_version, shapes)
+    result["get"] = create_get_operation(operation, operation_name, api_version, shapes, openapi_spec, path_key)
 
     # POST method - parameters in body
     result["post"] = create_post_operation(operation, operation_name, api_version, shapes)
@@ -202,16 +197,11 @@ def create_path(operation, api_version, shapes):
     return result
 
 
-def create_get_operation(operation, operation_name, api_version, shapes):
+def create_get_operation(operation, operation_name, api_version, shapes, openapi_spec, path_key):
     op = {}
 
-    op["x-aws-operation-name"] = operation_name
     op["operationId"] = f"GET_{operation_name}"
     op["description"] = LiteralStr(html_to_md(operation["traits"].get("smithy.api#documentation", "")))
-    
-    # Add StackQL-specific fields
-    op["x-stackql-resource"] = derive_resource_name(operation_name)
-    op["x-stackql-verb"] = determine_stackql_verb("GET", operation_name)
 
     # Build parameters list
     parameters = []
@@ -269,19 +259,30 @@ def create_get_operation(operation, operation_name, api_version, shapes):
     # Response
     op["responses"] = create_responses(operation, shapes)
 
+    # Track operation for StackQL resource building (GET version)
+    resource_name = derive_resource_name(operation_name)
+    stackql_verb = determine_stackql_verb("GET", operation_name)
+    method_name = derive_method_name(operation_name)
+
+    openapi_spec["_stackql_operations"].append({
+        "operation_id": f"GET_{operation_name}",
+        "resource_name": resource_name,
+        "stackql_verb": stackql_verb,
+        "method_name": method_name,
+        "path": path_key,
+        "http_method": "get",
+        "success_code": "200",
+        "shape_name": operation["my_name"]
+    })
+
     return op
 
 
 def create_post_operation(operation, operation_name, api_version, shapes):
     op = {}
 
-    op["x-aws-operation-name"] = operation_name
     op["operationId"] = f"POST_{operation_name}"
     op["description"] = LiteralStr(html_to_md(operation["traits"].get("smithy.api#documentation", "")))
-    
-    # Add StackQL-specific fields
-    op["x-stackql-resource"] = derive_resource_name(operation_name)
-    op["x-stackql-verb"] = determine_stackql_verb("POST", operation_name)
 
     # Parameters (Action and Version in query string for POST too)
     op["parameters"] = [

--- a/smithy-to-openapi/processors/ec2_query.py
+++ b/smithy-to-openapi/processors/ec2_query.py
@@ -30,10 +30,9 @@ from processors.shared_functions import (
     write_output_yaml,
     derive_resource_name,
     determine_stackql_verb,
+    derive_method_name,
     detect_pagination_scheme,
     add_pagination_to_info,
-    add_pagination_to_operation,
-    resolve_orphaned_schemas,
 )
 
 yaml.add_representer(LiteralStr, literal_str_representer)
@@ -168,24 +167,20 @@ def process(model_entry):
     for operation in shapes_dict["operation"]:
         operation_name = operation["my_name"].split('#')[1]
         key_string = f"/#Action={operation_name}"
-        path_spec = create_path(operation, api_version, shapes)
+        path_spec = create_path(operation, api_version, shapes, openapi_spec)
         openapi_spec["paths"][key_string] = path_spec
-        # Add pagination override if this operation is an exception
-        add_pagination_to_operation(openapi_spec, operation["my_name"], path_spec["get"])
-
-    # Resolve any orphaned schema references
-    resolve_orphaned_schemas(openapi_spec)
 
     # Write output YAML
     write_output_yaml(openapi_spec, service_dir)
 
 
-def create_path(operation, api_version, shapes):
+def create_path(operation, api_version, shapes, openapi_spec):
     result = {}
     operation_name = operation["my_name"].split('#')[1]
+    path_key = f"/#Action={operation_name}"
 
     # GET method - parameters in query string
-    result["get"] = create_get_operation(operation, operation_name, api_version, shapes)
+    result["get"] = create_get_operation(operation, operation_name, api_version, shapes, openapi_spec, path_key)
 
     # AWS signature parameters at path level
     result["parameters"] = [
@@ -204,16 +199,11 @@ def create_path(operation, api_version, shapes):
     return result
 
 
-def create_get_operation(operation, operation_name, api_version, shapes):
+def create_get_operation(operation, operation_name, api_version, shapes, openapi_spec, path_key):
     op = {}
 
-    op["x-aws-operation-name"] = operation_name
     op["operationId"] = f"GET_{operation_name}"
     op["description"] = LiteralStr(html_to_md(operation["traits"].get("smithy.api#documentation", "")))
-    
-    # Add StackQL-specific fields
-    op["x-stackql-resource"] = derive_resource_name(operation_name)
-    op["x-stackql-verb"] = determine_stackql_verb("GET", operation_name)
 
     # Response first (following the example order)
     op["responses"] = create_responses(operation, shapes)
@@ -290,19 +280,30 @@ def create_get_operation(operation, operation_name, api_version, shapes):
 
     op["parameters"] = parameters
 
+    # Track operation for StackQL resource building (GET version)
+    resource_name = derive_resource_name(operation_name)
+    stackql_verb = determine_stackql_verb("GET", operation_name)
+    method_name = derive_method_name(operation_name)
+
+    openapi_spec["_stackql_operations"].append({
+        "operation_id": f"GET_{operation_name}",
+        "resource_name": resource_name,
+        "stackql_verb": stackql_verb,
+        "method_name": method_name,
+        "path": path_key,
+        "http_method": "get",
+        "success_code": "200",
+        "shape_name": operation["my_name"]
+    })
+
     return op
 
 
 def create_post_operation(operation, operation_name, api_version, shapes):
     op = {}
 
-    op["x-aws-operation-name"] = operation_name
     op["operationId"] = f"POST_{operation_name}"
     op["description"] = LiteralStr(html_to_md(operation["traits"].get("smithy.api#documentation", "")))
-    
-    # Add StackQL-specific fields
-    op["x-stackql-resource"] = derive_resource_name(operation_name)
-    op["x-stackql-verb"] = determine_stackql_verb("POST", operation_name)
 
     # Response first
     op["responses"] = create_responses(operation, shapes)

--- a/smithy-to-openapi/processors/rest_json1.py
+++ b/smithy-to-openapi/processors/rest_json1.py
@@ -25,7 +25,6 @@ from processors.shared_functions import (
     add_operation,
     detect_pagination_scheme,
     add_pagination_to_info,
-    resolve_orphaned_schemas,
     write_output_yaml,
 )
 
@@ -94,8 +93,5 @@ def process(model_entry):
         elif shape.get("type") == "operation":
             add_operation(openapi_spec, shape_name, shape, shapes)
 
-    # Resolve any orphaned schema references
-    resolve_orphaned_schemas(openapi_spec)
-
-    # Write output YAML
+    # Write output YAML (this also finalizes StackQL resources and resolves orphaned schemas)
     write_output_yaml(openapi_spec, service_dir)

--- a/smithy-to-openapi/processors/rest_xml.py
+++ b/smithy-to-openapi/processors/rest_xml.py
@@ -28,10 +28,9 @@ from processors.shared_functions import (
     write_output_yaml,
     derive_resource_name,
     determine_stackql_verb,
+    derive_method_name,
     detect_pagination_scheme,
     add_pagination_to_info,
-    add_pagination_to_operation,
-    resolve_orphaned_schemas,
 )
 
 yaml.add_representer(LiteralStr, literal_str_representer)
@@ -99,10 +98,7 @@ def process(model_entry):
         elif shape.get("type") == "operation":
             add_operation_xml(openapi_spec, shape_name, shape, shapes)
 
-    # Resolve any orphaned schema references
-    resolve_orphaned_schemas(openapi_spec)
-
-    # Write output YAML
+    # Write output YAML (this also finalizes StackQL resources and resolves orphaned schemas)
     write_output_yaml(openapi_spec, service_dir)
 
 
@@ -130,11 +126,22 @@ def add_operation_xml(openapi_spec, shape_name, shape, shapes):
         openapi_spec["paths"][path][verb] = {}
 
     openapi_spec["paths"][path][verb]["operationId"] = operation_id
-    openapi_spec["paths"][path][verb]["x-aws-operation-name"] = operation_id
 
-    # Add StackQL-specific fields
-    openapi_spec["paths"][path][verb]["x-stackql-resource"] = derive_resource_name(operation_id)
-    openapi_spec["paths"][path][verb]["x-stackql-verb"] = determine_stackql_verb(verb, operation_id)
+    # Track operation for StackQL resource building
+    resource_name = derive_resource_name(operation_id)
+    stackql_verb = determine_stackql_verb(verb, operation_id)
+    method_name = derive_method_name(operation_id)
+
+    openapi_spec["_stackql_operations"].append({
+        "operation_id": operation_id,
+        "resource_name": resource_name,
+        "stackql_verb": stackql_verb,
+        "method_name": method_name,
+        "path": path,
+        "http_method": verb,
+        "success_code": str(success_code),
+        "shape_name": shape_name
+    })
 
     if "smithy.api#documentation" in traits:
         description = LiteralStr(html_to_md(shape["traits"]["smithy.api#documentation"]))
@@ -258,6 +265,3 @@ def add_operation_xml(openapi_spec, shape_name, shape, shapes):
                 responses[str(error_code)]["description"] = LiteralStr(html_to_md(error_traits["smithy.api#documentation"]))
             else:
                 responses[str(error_code)]["description"] = error_component_name
-
-    # Add pagination override if this operation is an exception
-    add_pagination_to_operation(openapi_spec, shape_name, openapi_spec["paths"][path][verb])

--- a/smithy-to-openapi/processors/shared_functions.py
+++ b/smithy-to-openapi/processors/shared_functions.py
@@ -4,11 +4,19 @@ import sys,html2text
 from yaml.representer import SafeRepresenter
 from datetime import date
 from pathlib import Path
+from collections import defaultdict
 import yaml
 import inflect
+import re
 
 # Initialize inflect engine for pluralization
 _inflect_engine = inflect.engine()
+
+# Provider version constant
+PROVIDER_VERSION = "v00.00.00000"
+
+# Track all processed services for provider.yaml generation
+_processed_services = []
 
 class LiteralStr(str): pass
 
@@ -122,54 +130,54 @@ def _pluralize_resource(resource_name: str) -> str:
 def determine_stackql_verb(http_method: str, operation_id: str) -> str:
     """
     Determine the appropriate StackQL verb based on HTTP method and operation semantics.
-    
+
     StackQL verbs:
     - select: Read operations (GET, or POST operations that retrieve data like Describe, List, Get)
     - insert: Create operations
     - update: Update/modify operations
     - delete: Delete operations
     - exec: Other operations that don't fit the CRUD pattern
-    
+
     GUARDRAIL: HTTP DELETE method MUST ALWAYS map to 'delete' verb, regardless of operation name.
-    
+
     Note: POST operations that retrieve data (Describe*, List*, Get*) are treated as 'select'
     """
     http_method = http_method.upper()
-    
+
     # CRITICAL GUARDRAIL: HTTP DELETE must ALWAYS be 'delete'
     # This ensures we never have select/insert/update operations using DELETE
     if http_method == 'DELETE':
         return 'delete'
-    
+
     # Patterns for select operations (data retrieval)
     select_patterns = ['Describe', 'Get', 'List', 'Query', 'Search', 'Lookup', 'Find', 'Retrieve', 'Read', 'Show', 'Scan']
-    
+
     # Patterns for insert operations
     insert_patterns = ['Create', 'Put', 'Add', 'Register', 'Enable', 'Batch']
-    
+
     # Patterns for update operations
     update_patterns = ['Update', 'Modify', 'Set', 'Change', 'Replace', 'Edit', 'Apply', 'Attach', 'Detach']
-    
+
     # Patterns for delete operations
     delete_patterns = ['Delete', 'Remove', 'Terminate', 'Deregister', 'Disable', 'Cancel']
-    
+
     # Check operation ID patterns first (more specific than HTTP method)
     for pattern in select_patterns:
         if operation_id.startswith(pattern):
             return 'select'
-    
+
     for pattern in insert_patterns:
         if operation_id.startswith(pattern):
             return 'insert'
-    
+
     for pattern in update_patterns:
         if operation_id.startswith(pattern):
             return 'update'
-    
+
     for pattern in delete_patterns:
         if operation_id.startswith(pattern):
             return 'delete'
-    
+
     # Fall back to HTTP method mapping
     if http_method == 'GET':
         return 'select'
@@ -183,31 +191,55 @@ def determine_stackql_verb(http_method: str, operation_id: str) -> str:
     else:
         return 'exec'
 
+def derive_method_name(operation_id: str) -> str:
+    """
+    Derive the method name from the operationId.
+
+    Extracts the verb/action and converts to snake_case.
+
+    Examples:
+    - DescribeAutoScalingGroups -> describe_auto_scaling_groups
+    - CreateLaunchConfiguration -> create_launch_configuration
+    - GetObject -> get_object
+    - ListBuckets -> list_buckets
+    """
+    if not operation_id:
+        return ""
+
+    # Convert from PascalCase to snake_case
+    method_name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', operation_id)
+    method_name = re.sub('([a-z0-9])([A-Z])', r'\1_\2', method_name)
+    method_name = method_name.lower()
+
+    return method_name
+
 def init_openapi_spec(service_name, service_dir, protocol, version=None, filename=None):
     info = {
         "contact": {
             "name": "StackQL Studios",
             "url": "https://stackql.io/",
             "email": "info@stackql.io"
-        },
-        "x-stackql-serviceName": service_dir.replace("-", "_"),
-        "x-aws-serviceName": service_name,
-        "x-aws-protocol": protocol,
-        "x-dateGenerated": f"{date.today().isoformat()}"
+        }
     }
-    
+
     # Add GitHub deep link to model file if version and filename are provided
     if version and filename:
         info["x-aws-modelFile"] = f"https://github.com/aws/api-models-aws/tree/main/models/{service_dir}/service/{version}/{filename}"
-    
+
     return {
         "openapi": "3.1.0",
         "info": info,
         "servers": [],
         "paths": {},
         "components": {
-            "schemas": {}
-        }
+            "schemas": {},
+            "x-stackQL-resources": {}
+        },
+        # Internal tracking for building resources (removed before output)
+        "_stackql_operations": [],
+        "_service_name": service_dir.replace("-", "_"),
+        "_aws_service_name": service_name,
+        "_aws_protocol": protocol
     }
 
 def add_info(openapi_spec, service_shape, version=None):
@@ -676,7 +708,7 @@ def add_component_schema_structure(openapi_spec, shape_name, shape):
 def add_operation(openapi_spec, shape_name, shape, shapes):
     operation_id = shape_name.split("#")[-1]
     print(f"adding operation {operation_id}")
-    
+
     # process traits
     traits = shape.get("traits", {})
     http = traits.get("smithy.api#http", {})
@@ -698,17 +730,23 @@ def add_operation(openapi_spec, shape_name, shape, shapes):
     if "smithy.api#documentation" in traits:
         description = LiteralStr(html_to_md(shape["traits"]["smithy.api#documentation"]))
         openapi_spec["paths"][path][verb]["description"] = description
-    
-    # Add StackQL-specific fields
+
+    # Track operation info for building StackQL resources later
     resource_name = derive_resource_name(operation_id)
     stackql_verb = determine_stackql_verb(verb, operation_id)
-    
-    openapi_spec["paths"][path][verb]["x-stackql-resource"] = resource_name
-    openapi_spec["paths"][path][verb]["x-stackql-verb"] = stackql_verb
-    
-    # Add operation-level pagination metadata if this operation differs from dominant scheme
-    add_pagination_to_operation(openapi_spec, shape_name, openapi_spec["paths"][path][verb])
-    
+    method_name = derive_method_name(operation_id)
+
+    openapi_spec["_stackql_operations"].append({
+        "operation_id": operation_id,
+        "resource_name": resource_name,
+        "stackql_verb": stackql_verb,
+        "method_name": method_name,
+        "path": path,
+        "http_method": verb,
+        "success_code": str(success_code),
+        "shape_name": shape_name
+    })
+
     input_shape_name = shape.get("input", {}).get("target")
     if input_shape_name and input_shape_name != "smithy.api#Unit":
         input_shape = shapes[input_shape_name]
@@ -765,7 +803,7 @@ def add_operation(openapi_spec, shape_name, shape, shapes):
 
     # process output
     openapi_spec["paths"][path][verb]["responses"] = {}
-    
+
     # Handle success response with output shape
     output_shape_name = shape.get("output", {}).get("target")
     if output_shape_name and output_shape_name != "smithy.api#Unit":
@@ -783,7 +821,7 @@ def add_operation(openapi_spec, shape_name, shape, shapes):
         openapi_spec["paths"][path][verb]["responses"][str(success_code)] = {
             "description": "Success"
         }
-    
+
     if "errors" in shape:
         for error in shape["errors"]:
             error_component_name = error["target"].split("#")[-1]
@@ -946,43 +984,136 @@ def detect_pagination_scheme(shapes, protocol):
 
 def add_pagination_to_info(openapi_spec, pagination_data):
     """
-    Add pagination metadata to the OpenAPI spec's info section.
-    Uses the dominant scheme for service-level metadata.
-    
+    Store pagination data in the spec for later use when building StackQL config.
+
     Args:
         openapi_spec: The OpenAPI specification dictionary
         pagination_data: Dictionary with dominant_scheme and exceptions from detect_pagination_scheme
     """
     if not pagination_data:
+        openapi_spec["_pagination_data"] = None
         return
-    
-    dominant_scheme = pagination_data['dominant_scheme']
-    
-    openapi_spec["info"]["x-pagination-request-key"] = dominant_scheme['request_key']
-    openapi_spec["info"]["x-pagination-request-location"] = dominant_scheme['request_location']
-    openapi_spec["info"]["x-pagination-response-key"] = dominant_scheme['response_key']
-    openapi_spec["info"]["x-pagination-response-location"] = dominant_scheme['response_location']
-    
-    # Store exceptions for later use when adding operations
-    openapi_spec["_pagination_exceptions"] = pagination_data['exceptions']
+
+    openapi_spec["_pagination_data"] = pagination_data
 
 def add_pagination_to_operation(openapi_spec, shape_name, operation_spec):
     """
-    Add operation-level pagination metadata if this operation differs from the dominant scheme.
-    
-    Args:
-        openapi_spec: The OpenAPI specification dictionary
-        shape_name: The full shape name (e.g., 'com.amazonaws.service#OperationName')
-        operation_spec: The operation specification dictionary to potentially add pagination to
+    No longer adds operation-level pagination metadata directly.
+    This is now handled during resource building in build_stackql_resources.
+    Kept for backwards compatibility with processor calls.
     """
-    pagination_exceptions = openapi_spec.get("_pagination_exceptions", {})
-    
-    if shape_name in pagination_exceptions:
-        exception_scheme = pagination_exceptions[shape_name]
-        operation_spec["x-pagination-request-key"] = exception_scheme['request_key']
-        operation_spec["x-pagination-request-location"] = exception_scheme['request_location']
-        operation_spec["x-pagination-response-key"] = exception_scheme['response_key']
-        operation_spec["x-pagination-response-location"] = exception_scheme['response_location']
+    pass
+
+
+def _escape_path_for_ref(path: str) -> str:
+    """Escape a path string for use in JSON pointer ($ref)."""
+    # JSON pointer requires ~ to be encoded as ~0, / as ~1
+    return path.replace("~", "~0").replace("/", "~1")
+
+
+def build_stackql_resources(openapi_spec):
+    """
+    Build the x-stackQL-resources section from tracked operations.
+
+    Groups operations by resource name, creates methods referencing paths,
+    and builds sqlVerbs mappings.
+    """
+    service_name = openapi_spec.get("_service_name", "unknown")
+    operations = openapi_spec.get("_stackql_operations", [])
+
+    # Group operations by resource name
+    resources = defaultdict(lambda: {
+        "methods": {},
+        "sqlVerbs": {
+            "select": [],
+            "insert": [],
+            "update": [],
+            "delete": []
+        }
+    })
+
+    for op in operations:
+        resource_name = op["resource_name"]
+        method_name = op["method_name"]
+        path = op["path"]
+        http_method = op["http_method"]
+        stackql_verb = op["stackql_verb"]
+        success_code = op["success_code"]
+
+        # Build the path reference for the operation
+        escaped_path = _escape_path_for_ref(path)
+        operation_ref = f"#/paths/{escaped_path}/{http_method}"
+
+        # Build method definition
+        method_def = {
+            "operation": {
+                "$ref": operation_ref
+            },
+            "response": {
+                "mediaType": "application/json",
+                "openAPIDocKey": success_code
+            }
+        }
+
+        # Add request mediaType for write operations
+        if stackql_verb in ("insert", "update", "exec"):
+            method_def["request"] = {
+                "mediaType": "application/json"
+            }
+
+        resources[resource_name]["methods"][method_name] = method_def
+
+        # Add to appropriate sqlVerb list (exec operations don't get added to sqlVerbs)
+        if stackql_verb in resources[resource_name]["sqlVerbs"]:
+            method_ref = f"#/components/x-stackQL-resources/{resource_name}/methods/{method_name}"
+            resources[resource_name]["sqlVerbs"][stackql_verb].append({
+                "$ref": method_ref
+            })
+
+    # Build final resource definitions
+    stackql_resources = {}
+    for resource_name, resource_data in sorted(resources.items()):
+        stackql_resources[resource_name] = {
+            "id": f"aws.{service_name}.{resource_name}",
+            "name": resource_name,
+            "title": resource_name.replace("_", " ").title(),
+            "methods": resource_data["methods"],
+            "sqlVerbs": resource_data["sqlVerbs"]
+        }
+
+    openapi_spec["components"]["x-stackQL-resources"] = stackql_resources
+
+
+def build_stackql_config(openapi_spec):
+    """
+    Build the x-stackQL-config section with AWS authentication and pagination.
+    """
+    service_name = openapi_spec.get("_service_name", "unknown")
+    pagination_data = openapi_spec.get("_pagination_data")
+
+    config = {
+        "auth": {
+            "type": "aws_signing_v4",
+            "credentialsenvvar": "AWS_SECRET_ACCESS_KEY",
+            "keyIDenvvar": "AWS_ACCESS_KEY_ID"
+        }
+    }
+
+    # Add pagination config if detected
+    if pagination_data and pagination_data.get("dominant_scheme"):
+        scheme = pagination_data["dominant_scheme"]
+        config["pagination"] = {
+            "requestToken": {
+                "key": scheme["request_key"],
+                "location": scheme["request_location"]
+            },
+            "responseToken": {
+                "key": scheme["response_key"],
+                "location": scheme["response_location"]
+            }
+        }
+
+    openapi_spec["x-stackQL-config"] = config
 
 def resolve_orphaned_schemas(openapi_spec):
     """
@@ -1060,13 +1191,122 @@ def resolve_orphaned_schemas(openapi_spec):
         
         print(f"  ✓ Created placeholder definitions for orphaned schemas")
 
+def finalize_openapi_spec(openapi_spec):
+    """
+    Finalize the OpenAPI spec by building StackQL resources and config,
+    then cleaning up internal tracking fields.
+    """
+    # Build StackQL resources from tracked operations
+    build_stackql_resources(openapi_spec)
+
+    # Build StackQL config with auth and pagination
+    build_stackql_config(openapi_spec)
+
+    # Clean up internal tracking fields
+    internal_fields = [
+        "_stackql_operations",
+        "_service_name",
+        "_aws_service_name",
+        "_aws_protocol",
+        "_pagination_data",
+        "_pagination_exceptions"
+    ]
+    for field in internal_fields:
+        if field in openapi_spec:
+            del openapi_spec[field]
+
+
 def write_output_yaml(openapi_spec, service_dir):
-    # Clean up temporary pagination exceptions storage
-    if "_pagination_exceptions" in openapi_spec:
-        del openapi_spec["_pagination_exceptions"]
-    
-    outdir = Path("smithy-to-openapi/openapi")
-    outdir.mkdir(exist_ok=True)
-    outfile = outdir / f"{service_dir.replace('-', '_')}.yaml"
+    global _processed_services
+
+    # Finalize the spec (build resources, config, clean up)
+    finalize_openapi_spec(openapi_spec)
+
+    # Resolve any orphaned schema references
+    resolve_orphaned_schemas(openapi_spec)
+
+    # Create output directory structure
+    outdir = Path(f"smithy-to-openapi/openapi/src/aws/{PROVIDER_VERSION}/services")
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    service_name = service_dir.replace('-', '_')
+    outfile = outdir / f"{service_name}.yaml"
+
     with open(outfile, "w", encoding="utf-8") as f:
         yaml.dump(openapi_spec, f, sort_keys=False, allow_unicode=True)
+
+    print(f"  ✓ Wrote {outfile}")
+
+    # Track this service for provider.yaml generation
+    _processed_services.append({
+        "name": service_name,
+        "title": openapi_spec.get("info", {}).get("title", service_name),
+        "description": openapi_spec.get("info", {}).get("description", ""),
+        "version": openapi_spec.get("info", {}).get("version", "1.0.0")
+    })
+
+
+def get_processed_services():
+    """Return the list of processed services."""
+    global _processed_services
+    return _processed_services
+
+
+def reset_processed_services():
+    """Reset the list of processed services (for testing)."""
+    global _processed_services
+    _processed_services = []
+
+
+def generate_provider_yaml():
+    """
+    Generate the provider.yaml file that indexes all processed services.
+    """
+    global _processed_services
+
+    if not _processed_services:
+        print("⚠️  No services processed, skipping provider.yaml generation")
+        return
+
+    provider = {
+        "id": "aws",
+        "name": "aws",
+        "title": "Amazon Web Services",
+        "version": PROVIDER_VERSION,
+        "description": "Cloud computing services from Amazon Web Services.",
+        "providerServices": {}
+    }
+
+    # Add each service to providerServices
+    for svc in sorted(_processed_services, key=lambda x: x["name"]):
+        service_name = svc["name"]
+        provider["providerServices"][service_name] = {
+            "id": f"aws.{service_name}",
+            "name": service_name,
+            "title": svc["title"],
+            "version": svc["version"],
+            "description": svc.get("description", "")[:200] if svc.get("description") else "",
+            "preferred": True,
+            "service": {
+                "$ref": f"services/{service_name}.yaml"
+            }
+        }
+
+    # Add provider-level config
+    provider["config"] = {
+        "auth": {
+            "type": "aws_signing_v4",
+            "credentialsenvvar": "AWS_SECRET_ACCESS_KEY",
+            "keyIDenvvar": "AWS_ACCESS_KEY_ID"
+        }
+    }
+
+    # Write provider.yaml
+    outdir = Path(f"smithy-to-openapi/openapi/src/aws/{PROVIDER_VERSION}")
+    outdir.mkdir(parents=True, exist_ok=True)
+    outfile = outdir / "provider.yaml"
+
+    with open(outfile, "w", encoding="utf-8") as f:
+        yaml.dump(provider, f, sort_keys=False, allow_unicode=True)
+
+    print(f"✓ Generated provider.yaml with {len(_processed_services)} services")


### PR DESCRIPTION
Refactored the OpenAPI generation to produce complete StackQL providers in one step instead of adding x-stackql-* tags for post-processing.

Key changes:
- Generate x-stackQL-resources with proper method references and sqlVerbs
- Add x-stackQL-config with AWS auth and pagination configuration
- Output to services/ directory with provider.yaml index file
- Updated all protocol processors to track operations for resource building
- Removed redundant x-stackql-resource and x-stackql-verb tags from operations

Please read the [Contributing Guidelines](CONTRIBUTING.md) before submitting a
pull request. We cannot accept pull requests against the generated models in
this repository

## Describe your changes

## Link to the relevant issue(s)

## Checklist
- [ ] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [ ] I confirm that this pull request is not against the generated models.
- [ ] My contribution is licensed under the [Apache-2.0 license](LICENSE).
