### PR TITLE
Integrate CSV manifest for StackQL resource generation

### DIFF
--- a/smithy-to-openapi/analyze_stackql_routes.py
+++ b/smithy-to-openapi/analyze_stackql_routes.py
@@ -15,8 +15,12 @@ Output:
     stackql-routes/{service}.csv - One CSV per service with operation mappings
 
 CSV Format:
-    operationId,path,verb,description,resource,method,sqlVerb,objectKey,
+    operationId,path,verb,description,resource,originalResourceName,method,sqlVerb,objectKey,
     reqPaginationKey,reqPaginationLocation,respPaginationKey,respPaginationLocation
+
+Note: For new operations, 'resource' is left empty and 'originalResourceName' contains the
+auto-derived name. If 'resource' is provided, it overrides 'originalResourceName'. Existing
+operations are preserved as-is to maintain human overrides.
 """
 
 import csv
@@ -152,7 +156,8 @@ def extract_operations_from_model(model_path: Path, service_name: str, protocol:
             "path": path,
             "verb": verb,
             "description": truncate_description(description),
-            "resource": resource,
+            "resource": "",  # Left empty for human override; use originalResourceName if not set
+            "originalResourceName": resource,  # Auto-derived resource name preserved here
             "method": method,
             "sqlVerb": sql_verb,
             "objectKey": "",  # To be filled in by human review if needed
@@ -267,6 +272,7 @@ def main():
         "verb",
         "description",
         "resource",
+        "originalResourceName",
         "method",
         "sqlVerb",
         "objectKey",

--- a/smithy-to-openapi/processors/aws_json_1_0.py
+++ b/smithy-to-openapi/processors/aws_json_1_0.py
@@ -26,9 +26,6 @@ from processors.shared_functions import (
     add_component_schema_union,
     add_component_schema_structure,
     write_output_yaml,
-    derive_resource_name,
-    determine_stackql_verb,
-    derive_method_name,
     detect_pagination_scheme,
     add_pagination_to_info,
 )
@@ -256,15 +253,10 @@ def create_path(operation, service_name2, openapi_spec):
             error_code += 1
 
     # Track operation for StackQL resource building
-    resource_name = derive_resource_name(operation_name)
-    stackql_verb = determine_stackql_verb("POST", operation_name)
-    method_name = derive_method_name(operation_name)
-
+    # Note: Resource name, method name, and SQL verb will be resolved from CSV manifest
+    # in build_stackql_resources() using get_operation_config()
     openapi_spec["_stackql_operations"].append({
         "operation_id": operation_name,
-        "resource_name": resource_name,
-        "stackql_verb": stackql_verb,
-        "method_name": method_name,
         "path": path_key,
         "http_method": "post",
         "success_code": "200",

--- a/smithy-to-openapi/processors/aws_json_1_1.py
+++ b/smithy-to-openapi/processors/aws_json_1_1.py
@@ -29,9 +29,6 @@ from processors.shared_functions import (
     detect_pagination_scheme,
     add_pagination_to_info,
     write_output_yaml,
-    derive_resource_name,
-    determine_stackql_verb,
-    derive_method_name,
 )
 
 yaml.add_representer(LiteralStr, literal_str_representer)
@@ -236,15 +233,10 @@ def create_path(operation, service_name2, openapi_spec):
             error_code += 1
 
     # Track operation for StackQL resource building
-    resource_name = derive_resource_name(operation_id)
-    stackql_verb = determine_stackql_verb("POST", operation_id)
-    method_name = derive_method_name(operation_id)
-
+    # Note: Resource name, method name, and SQL verb will be resolved from CSV manifest
+    # in build_stackql_resources() using get_operation_config()
     openapi_spec["_stackql_operations"].append({
         "operation_id": operation_id,
-        "resource_name": resource_name,
-        "stackql_verb": stackql_verb,
-        "method_name": method_name,
         "path": path_key,
         "http_method": "post",
         "success_code": "200",

--- a/smithy-to-openapi/processors/aws_query.py
+++ b/smithy-to-openapi/processors/aws_query.py
@@ -27,9 +27,6 @@ from processors.shared_functions import (
     add_component_schema_union,
     add_component_schema_structure,
     write_output_yaml,
-    derive_resource_name,
-    determine_stackql_verb,
-    derive_method_name,
     detect_pagination_scheme,
     add_pagination_to_info,
 )
@@ -260,15 +257,10 @@ def create_get_operation(operation, operation_name, api_version, shapes, openapi
     op["responses"] = create_responses(operation, shapes)
 
     # Track operation for StackQL resource building (GET version)
-    resource_name = derive_resource_name(operation_name)
-    stackql_verb = determine_stackql_verb("GET", operation_name)
-    method_name = derive_method_name(operation_name)
-
+    # Note: Resource name, method name, and SQL verb will be resolved from CSV manifest
+    # in build_stackql_resources() using get_operation_config()
     openapi_spec["_stackql_operations"].append({
-        "operation_id": f"GET_{operation_name}",
-        "resource_name": resource_name,
-        "stackql_verb": stackql_verb,
-        "method_name": method_name,
+        "operation_id": operation_name,
         "path": path_key,
         "http_method": "get",
         "success_code": "200",

--- a/smithy-to-openapi/processors/ec2_query.py
+++ b/smithy-to-openapi/processors/ec2_query.py
@@ -28,9 +28,6 @@ from processors.shared_functions import (
     add_component_schema_union,
     add_component_schema_structure,
     write_output_yaml,
-    derive_resource_name,
-    determine_stackql_verb,
-    derive_method_name,
     detect_pagination_scheme,
     add_pagination_to_info,
 )
@@ -281,15 +278,10 @@ def create_get_operation(operation, operation_name, api_version, shapes, openapi
     op["parameters"] = parameters
 
     # Track operation for StackQL resource building (GET version)
-    resource_name = derive_resource_name(operation_name)
-    stackql_verb = determine_stackql_verb("GET", operation_name)
-    method_name = derive_method_name(operation_name)
-
+    # Note: Resource name, method name, and SQL verb will be resolved from CSV manifest
+    # in build_stackql_resources() using get_operation_config()
     openapi_spec["_stackql_operations"].append({
-        "operation_id": f"GET_{operation_name}",
-        "resource_name": resource_name,
-        "stackql_verb": stackql_verb,
-        "method_name": method_name,
+        "operation_id": operation_name,
         "path": path_key,
         "http_method": "get",
         "success_code": "200",

--- a/smithy-to-openapi/processors/rest_xml.py
+++ b/smithy-to-openapi/processors/rest_xml.py
@@ -26,9 +26,6 @@ from processors.shared_functions import (
     add_component_schema_union,
     add_component_schema_structure,
     write_output_yaml,
-    derive_resource_name,
-    determine_stackql_verb,
-    derive_method_name,
     detect_pagination_scheme,
     add_pagination_to_info,
 )
@@ -128,15 +125,10 @@ def add_operation_xml(openapi_spec, shape_name, shape, shapes):
     openapi_spec["paths"][path][verb]["operationId"] = operation_id
 
     # Track operation for StackQL resource building
-    resource_name = derive_resource_name(operation_id)
-    stackql_verb = determine_stackql_verb(verb, operation_id)
-    method_name = derive_method_name(operation_id)
-
+    # Note: Resource name, method name, and SQL verb will be resolved from CSV manifest
+    # in build_stackql_resources() using get_operation_config()
     openapi_spec["_stackql_operations"].append({
         "operation_id": operation_id,
-        "resource_name": resource_name,
-        "stackql_verb": stackql_verb,
-        "method_name": method_name,
         "path": path,
         "http_method": verb,
         "success_code": str(success_code),

--- a/smithy-to-openapi/processors/shared_functions.py
+++ b/smithy-to-openapi/processors/shared_functions.py
@@ -265,6 +265,10 @@ def get_operation_config(service_name: str, operation_id: str, http_method: str)
     """
     Get operation configuration from CSV manifest or derive defaults.
 
+    The CSV manifest supports two resource name columns:
+    - 'resource': Human-overridden resource name (takes priority if set)
+    - 'originalResourceName': Auto-derived resource name (fallback)
+
     Args:
         service_name: The service name
         operation_id: The operation ID (e.g., 'DescribeInstances')
@@ -278,20 +282,28 @@ def get_operation_config(service_name: str, operation_id: str, http_method: str)
 
     if operation_id in manifest:
         row = manifest[operation_id]
+
+        # Resource name priority: resource (human override) > originalResourceName > derived
+        resource_name = row.get("resource", "").strip()
+        if not resource_name:
+            resource_name = row.get("originalResourceName", "").strip()
+        if not resource_name:
+            resource_name = derive_resource_name(operation_id)
+
         config = {
-            "resource_name": row.get("resource", "") or derive_resource_name(operation_id),
-            "method_name": row.get("method", "") or derive_method_name(operation_id),
-            "stackql_verb": row.get("sqlVerb", "") or determine_stackql_verb(http_method, operation_id),
-            "object_key": row.get("objectKey", ""),
+            "resource_name": resource_name,
+            "method_name": row.get("method", "").strip() or derive_method_name(operation_id),
+            "stackql_verb": row.get("sqlVerb", "").strip() or determine_stackql_verb(http_method, operation_id),
+            "object_key": row.get("objectKey", "").strip(),
         }
 
-        # Add pagination overrides if present
-        if row.get("reqPaginationKey"):
-            config["req_pagination_key"] = row["reqPaginationKey"]
-            config["req_pagination_location"] = row.get("reqPaginationLocation", "body")
-        if row.get("respPaginationKey"):
-            config["resp_pagination_key"] = row["respPaginationKey"]
-            config["resp_pagination_location"] = row.get("respPaginationLocation", "body")
+        # Add pagination overrides if present (operation-level overrides)
+        if row.get("reqPaginationKey", "").strip():
+            config["req_pagination_key"] = row["reqPaginationKey"].strip()
+            config["req_pagination_location"] = row.get("reqPaginationLocation", "body").strip() or "body"
+        if row.get("respPaginationKey", "").strip():
+            config["resp_pagination_key"] = row["respPaginationKey"].strip()
+            config["resp_pagination_location"] = row.get("respPaginationLocation", "body").strip() or "body"
 
         return config
 
@@ -829,15 +841,10 @@ def add_operation(openapi_spec, shape_name, shape, shapes):
         openapi_spec["paths"][path][verb]["description"] = description
 
     # Track operation info for building StackQL resources later
-    resource_name = derive_resource_name(operation_id)
-    stackql_verb = determine_stackql_verb(verb, operation_id)
-    method_name = derive_method_name(operation_id)
-
+    # Note: Resource name, method name, and SQL verb will be resolved from CSV manifest
+    # in build_stackql_resources() using get_operation_config()
     openapi_spec["_stackql_operations"].append({
         "operation_id": operation_id,
-        "resource_name": resource_name,
-        "stackql_verb": stackql_verb,
-        "method_name": method_name,
         "path": path,
         "http_method": verb,
         "success_code": str(success_code),
@@ -1112,11 +1119,18 @@ def build_stackql_resources(openapi_spec):
     """
     Build the x-stackQL-resources section from tracked operations.
 
-    Groups operations by resource name, creates methods referencing paths,
-    and builds sqlVerbs mappings.
+    Groups operations by resource name (from CSV manifest), creates methods
+    referencing paths, and builds sqlVerbs mappings.
+
+    Pagination overrides at the operation level are added to method definitions
+    when they differ from the service-level pagination configuration.
     """
     service_name = openapi_spec.get("_service_name", "unknown")
     operations = openapi_spec.get("_stackql_operations", [])
+    pagination_data = openapi_spec.get("_pagination_data")
+
+    # Get service-level pagination scheme for comparison
+    service_pagination = pagination_data.get("dominant_scheme") if pagination_data else None
 
     # Group operations by resource name
     resources = defaultdict(lambda: {
@@ -1130,11 +1144,18 @@ def build_stackql_resources(openapi_spec):
     })
 
     for op in operations:
-        resource_name = op["resource_name"]
-        method_name = op["method_name"]
+        # Get operation config from CSV manifest (includes resource_name, method_name, pagination overrides)
+        operation_id = op.get("operation_id", "").replace("GET_", "").replace("POST_", "")
+        op_config = get_operation_config(service_name, operation_id, op["http_method"].upper())
+
+        # Use CSV manifest values (with fallbacks already handled in get_operation_config)
+        resource_name = op_config["resource_name"]
+        method_name = op_config["method_name"]
+        stackql_verb = op_config["stackql_verb"]
+        object_key = op_config.get("object_key", "")
+
         path = op["path"]
         http_method = op["http_method"]
-        stackql_verb = op["stackql_verb"]
         success_code = op["success_code"]
 
         # Build the path reference for the operation
@@ -1152,11 +1173,49 @@ def build_stackql_resources(openapi_spec):
             }
         }
 
+        # Add objectKey if specified in CSV manifest
+        if object_key:
+            method_def["response"]["objectKey"] = object_key
+
         # Add request mediaType for write operations
         if stackql_verb in ("insert", "update", "exec"):
             method_def["request"] = {
                 "mediaType": "application/json"
             }
+
+        # Add operation-level pagination override if it differs from service-level
+        if "req_pagination_key" in op_config or "resp_pagination_key" in op_config:
+            # Check if this differs from service-level pagination
+            needs_override = False
+            if service_pagination:
+                req_key = op_config.get("req_pagination_key", "")
+                req_loc = op_config.get("req_pagination_location", "body")
+                resp_key = op_config.get("resp_pagination_key", "")
+                resp_loc = op_config.get("resp_pagination_location", "body")
+
+                if (req_key != service_pagination.get("request_key", "") or
+                    req_loc != service_pagination.get("request_location", "body") or
+                    resp_key != service_pagination.get("response_key", "") or
+                    resp_loc != service_pagination.get("response_location", "body")):
+                    needs_override = True
+            else:
+                # No service-level pagination, so any operation-level pagination is an override
+                needs_override = True
+
+            if needs_override:
+                pagination_override = {}
+                if op_config.get("req_pagination_key"):
+                    pagination_override["requestToken"] = {
+                        "key": op_config["req_pagination_key"],
+                        "location": op_config.get("req_pagination_location", "body")
+                    }
+                if op_config.get("resp_pagination_key"):
+                    pagination_override["responseToken"] = {
+                        "key": op_config["resp_pagination_key"],
+                        "location": op_config.get("resp_pagination_location", "body")
+                    }
+                if pagination_override:
+                    method_def["pagination"] = pagination_override
 
         resources[resource_name]["methods"][method_name] = method_def
 


### PR DESCRIPTION
- Modify analyze_stackql_routes.py to put derived resource names in originalResourceName column and leave resource column empty for new operations (preserving existing entries as-is)
- Update get_operation_config() in shared_functions.py to use originalResourceName as fallback when resource column is empty
- Update build_stackql_resources() to read resource names, method names, SQL verbs, and pagination overrides from CSV manifest
- Add operation-level pagination overrides when they differ from service-level pagination configuration
- Simplify operation tracking in all processors (aws_query, ec2_query, aws_json_1_0, aws_json_1_1, rest_xml) by deferring resource resolution to build_stackql_resources()

Please read the [Contributing Guidelines](CONTRIBUTING.md) before submitting a
pull request. We cannot accept pull requests against the generated models in
this repository

## Describe your changes

## Link to the relevant issue(s)

## Checklist
- [ ] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [ ] I confirm that this pull request is not against the generated models.
- [ ] My contribution is licensed under the [Apache-2.0 license](LICENSE).
